### PR TITLE
Rename invoice to result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ jobs:
         - npm install -g yarn
         - yarn install
       before_script:
-        - docker pull kodebox/codechain:5492602ba050cc823b26084ca61f12957b4b82e9
-        - docker run -d -p 8080:8080 kodebox/codechain:5492602ba050cc823b26084ca61f12957b4b82e9 --jsonrpc-interface 0.0.0.0 -c solo --reseal-min-period 0 --enable-devel-api
+        - docker pull kodebox/codechain:c6ca38e14dde18650e7fe36eb7c47213625a8d02
+        - docker run -d -p 8080:8080 kodebox/codechain:c6ca38e14dde18650e7fe36eb7c47213625a8d02 --jsonrpc-interface 0.0.0.0 -c solo --reseal-min-period 0 --enable-devel-api
         - psql -c 'CREATE DATABASE "codechain-indexer-test";' -U postgres
         - psql -c "CREATE USER \"user\" WITH ENCRYPTED PASSWORD 'password';" -U postgres
         - docker ps -a

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bignumber.js": "^7.2.1",
     "buffer": "^5.2.1",
     "codechain-indexer-types": "^0.6.0-alpha.0",
-    "codechain-sdk": "https://github.com/joojis/codechain-sdk-js.git#corgi",
+    "codechain-sdk": "https://github.com/sgkim126/codechain-sdk-js.git#result-lib",
     "cors": "^2.8.4",
     "dotenv": "^6.0.0",
     "express": "^4.16.3",

--- a/src/migrations/20181217110415-create-block.js
+++ b/src/migrations/20181217110415-create-block.js
@@ -36,7 +36,7 @@ module.exports = {
                     allowNull: false,
                     type: Sequelize.STRING
                 },
-                invoicesRoot: {
+                resultsRoot: {
                     allowNull: false,
                     type: Sequelize.STRING
                 },

--- a/src/models/block.ts
+++ b/src/models/block.ts
@@ -10,7 +10,7 @@ export interface BlockAttribute {
     extraData: Buffer;
     transactionsRoot: string;
     stateRoot: string;
-    invoicesRoot: string;
+    resultsRoot: string;
     score: string;
     seal: Buffer[];
     miningReward: string;
@@ -73,7 +73,7 @@ export default (
                     is: ["^[a-f0-9]{64}$"]
                 }
             },
-            invoicesRoot: {
+            resultsRoot: {
                 allowNull: false,
                 type: DataTypes.STRING,
                 validate: {

--- a/src/models/logic/block.ts
+++ b/src/models/logic/block.ts
@@ -26,7 +26,7 @@ export async function createBlock(
             extraData: Buffer.from(block.extraData),
             transactionsRoot: strip0xPrefix(block.transactionsRoot.value),
             stateRoot: strip0xPrefix(block.stateRoot.value),
-            invoicesRoot: strip0xPrefix(block.invoicesRoot.value),
+            resultsRoot: strip0xPrefix(block.resultsRoot.value),
             score: block.score.value.toString(10),
             seal: block.seal.map(s => Buffer.from(s)),
             hash: strip0xPrefix(block.hash.value),

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -148,8 +148,10 @@ export default class Worker {
         }
         const invoices = await Promise.all(
             block.transactions.map(async tx => {
-                const invoice = await sdk.rpc.chain.getInvoice(tx.hash());
-                if (invoice) {
+                const result = await sdk.rpc.chain.getTransactionResult(
+                    tx.hash()
+                );
+                if (result) {
                     return {
                         success: true,
                         errorHint: undefined

--- a/test/payment.spec.ts
+++ b/test/payment.spec.ts
@@ -54,10 +54,9 @@ test("Pay large amount", async done => {
             seq
         })
     );
-    const invoice = (await Helper.sdk.rpc.chain.getInvoice(hash, {
+    expect(await Helper.sdk.rpc.chain.getTransactionResult(hash, {
         timeout: 300 * 1000
-    }))!;
-    expect(invoice).toEqual(true);
+    })).toEqual(true);
 
     const paymentBlockNumber = await Helper.sdk.rpc.chain.getBestBlockNumber();
     const paymentBlock = await Helper.sdk.rpc.chain.getBlock(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,10 +1014,10 @@ codechain-primitives@^0.3.0:
     ripemd160 "^2.0.2"
     rlp "^2.1.0"
 
-codechain-primitives@^0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-0.4.7.tgz#4263b1dc550f793b1c1347c4a2d7236bb7327920"
-  integrity sha512-au4G3YfFsDdUl+35qBBwWOee9QvwV77mImOz8devKPzPu0+ssSeNortrPlY5VpqUkFNBUQsOpTtDe2IGdSeH6A==
+codechain-primitives@^0.4.6:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-0.4.8.tgz#5206ebcf92c0d225924931493b05c384d48fc63e"
+  integrity sha512-yEPinaK3y0pdMgmp7EjYkru2FL0XjXZ6sjdT4KmlGchqEuLUJsZ3V+MOyGlumdW7TSR7gpHl5+szyRPxUndMrQ==
   dependencies:
     bignumber.js "^7.2.1"
     blakejs "^1.1.0"
@@ -1030,13 +1030,13 @@ codechain-primitives@^0.4.7:
     ripemd160 "^2.0.2"
     rlp "^2.1.0"
 
-"codechain-sdk@https://github.com/joojis/codechain-sdk-js.git#corgi":
+"codechain-sdk@https://github.com/sgkim126/codechain-sdk-js.git#result-lib":
   version "0.5.1"
-  resolved "https://github.com/joojis/codechain-sdk-js.git#1cae9f16c0e8abaee4170767e81866b09f78fc20"
+  resolved "https://github.com/sgkim126/codechain-sdk-js.git#14e96f43faa29f33dfd876e6e3a54f7305926515"
   dependencies:
     buffer "5.1.0"
     codechain-keystore "^0.6.0"
-    codechain-primitives "^0.4.7"
+    codechain-primitives "^0.4.6"
     jayson "^2.0.6"
     lodash "^4.17.10"
     node-fetch "^2.1.2"


### PR DESCRIPTION
Currently, indexer has two invoice types. One is the invoice returned by
CodeChain, and the other is the invoice that indexer makes. The first
invoice is a boolean value that means the success of the transaction.
The second is an object `{ success: boolean, errorHint?: string }`.
This patch renames the first invoice to result since CodeChain renames
it, while the second invoice is left. So the object
`{ success: boolean, errorHint?: string }` becomes the only invoice type
from now.