### PR TITLE
Fix parameter descriptions in the Swagger

### DIFF
--- a/src/routers/account.ts
+++ b/src/routers/account.ts
@@ -18,12 +18,12 @@ export function handle(_C: IndexerContext, router: Router) {
      *     tags: [Account]
      *     parameters:
      *       - name: page
-     *         description: page for the pagination
+     *         description: page for the pagination (default 1)
      *         in: query
      *         required: false
      *         type: number
      *       - name: itemsPerPage
-     *         description: items per page for the pagination
+     *         description: items per page for the pagination (default 15)
      *         in: query
      *         required: false
      *         type: number

--- a/src/routers/asset.ts
+++ b/src/routers/asset.ts
@@ -75,12 +75,12 @@ export function handle(context: IndexerContext, router: Router) {
      *         required: false
      *         type: string
      *       - name: page
-     *         description: page for the pagination
+     *         description: page for the pagination (default 1)
      *         in: query
      *         required: false
      *         type: number
      *       - name: itemsPerPage
-     *         description: items per page for the pagination
+     *         description: items per page for the pagination (default 15)
      *         in: query
      *         required: false
      *         type: number
@@ -255,12 +255,12 @@ export function handle(context: IndexerContext, router: Router) {
      *         required: false
      *         type: string
      *       - name: page
-     *         description: page for the pagination
+     *         description: page for the pagination (default 1)
      *         in: query
      *         required: false
      *         type: number
      *       - name: itemsPerPage
-     *         description: items per page for the pagination
+     *         description: items per page for the pagination (default 15)
      *         in: query
      *         required: false
      *         type: number

--- a/src/routers/log.ts
+++ b/src/routers/log.ts
@@ -65,7 +65,7 @@ export function handle(_C: IndexerContext, router: Router) {
      *     tags: [Log]
      *     parameters:
      *       - name: date
-     *         description: (YYYY-MM-DD format)
+     *         description: YYYY-MM-DD (ISO8601 format)
      *         in: query
      *         required: true
      *         type: string


### PR DESCRIPTION
Some of the APIs didn't explained the default values of the parameters in the swagger.
I added some descriptions about the default values and format explanation.