### PR TITLE
Add an index field to the AssetTransferOutput table

### DIFF
--- a/src/migrations/20181223012324-create-asset-transfer-output.js
+++ b/src/migrations/20181223012324-create-asset-transfer-output.js
@@ -37,6 +37,10 @@ module.exports = {
                 allowNull: false,
                 type: Sequelize.NUMERIC({ precision: 20, scale: 0 })
             },
+            index: {
+                allowNull: false,
+                type: Sequelize.INTEGER
+            },
             owner: {
                 type: Sequelize.STRING
             },

--- a/src/models/assettransferoutput.ts
+++ b/src/models/assettransferoutput.ts
@@ -8,6 +8,7 @@ export interface AssetTransferOutputAttribute {
     assetType: string;
     shardId: number;
     quantity: string;
+    index: number;
     owner?: string | null;
 }
 
@@ -64,6 +65,10 @@ export default (
             quantity: {
                 allowNull: false,
                 type: DataTypes.NUMERIC({ precision: 20, scale: 0 })
+            },
+            index: {
+                allowNull: false,
+                type: DataTypes.INTEGER
             },
             owner: {
                 type: DataTypes.STRING

--- a/src/models/logic/assettransferoutput.ts
+++ b/src/models/logic/assettransferoutput.ts
@@ -1,4 +1,4 @@
-import { Asset, AssetTransferOutput } from "codechain-sdk/lib/core/classes";
+import { AssetTransferOutput } from "codechain-sdk/lib/core/classes";
 import * as Exception from "../../exception";
 import { AssetTransferOutputInstance } from "../assettransferoutput";
 import models from "../index";
@@ -8,9 +8,9 @@ import { strip0xPrefix } from "./utils/format";
 export async function createAssetTransferOutput(
     transactionHash: string,
     output: AssetTransferOutput,
+    index: number,
     params: {
         networkId: string;
-        asset: Asset;
     }
 ): Promise<AssetTransferOutputInstance> {
     let assetTransferOuputInstance: AssetTransferOutputInstance;
@@ -28,6 +28,7 @@ export async function createAssetTransferOutput(
             assetType: strip0xPrefix(output.assetType.value),
             shardId: output.shardId,
             quantity: output.quantity.value.toString(10),
+            index,
             owner
         });
     } catch (err) {

--- a/src/models/logic/decomposeAsset.ts
+++ b/src/models/logic/decomposeAsset.ts
@@ -1,4 +1,3 @@
-import { Asset } from "codechain-sdk/lib/core/Asset";
 import { SignedTransaction } from "codechain-sdk/lib/core/classes";
 import { AssetTransferOutput } from "codechain-sdk/lib/core/transaction/AssetTransferOutput";
 import {
@@ -33,19 +32,14 @@ export async function createDecomposeAsset(
         outputs.map(async (json: any, transactionOutputIndex: number) => {
             // FIXME
             const output = AssetTransferOutput.fromJSON(json);
-            await createAssetTransferOutput(transactionHash, output, {
-                networkId,
-                asset: new Asset({
-                    assetType: output.assetType,
-                    shardId: output.shardId,
-                    lockScriptHash: output.lockScriptHash,
-                    parameters: output.parameters,
-                    quantity: output.quantity,
-                    orderHash: null,
-                    tracker: decompose.tracker(),
-                    transactionOutputIndex
-                })
-            });
+            await createAssetTransferOutput(
+                transactionHash,
+                output,
+                transactionOutputIndex,
+                {
+                    networkId
+                }
+            );
         })
     );
     return result;

--- a/src/models/logic/transferAsset.ts
+++ b/src/models/logic/transferAsset.ts
@@ -1,4 +1,3 @@
-import { Asset } from "codechain-sdk/lib/core/Asset";
 import { SignedTransaction } from "codechain-sdk/lib/core/classes";
 import { AssetTransferOutput } from "codechain-sdk/lib/core/transaction/AssetTransferOutput";
 import {
@@ -49,19 +48,14 @@ export async function createTransferAsset(
     await Promise.all(
         outputs.map(async (json: any, transactionOutputIndex: number) => {
             const output = AssetTransferOutput.fromJSON(json);
-            return createAssetTransferOutput(transactionHash, output, {
-                networkId,
-                asset: new Asset({
-                    assetType: output.assetType,
-                    shardId: output.shardId,
-                    lockScriptHash: output.lockScriptHash,
-                    parameters: output.parameters,
-                    quantity: output.quantity,
-                    orderHash: null,
-                    tracker: transfer.tracker(),
-                    transactionOutputIndex
-                })
-            });
+            return createAssetTransferOutput(
+                transactionHash,
+                output,
+                transactionOutputIndex,
+                {
+                    networkId
+                }
+            );
         })
     );
     await Promise.all(

--- a/src/models/logic/utxo.ts
+++ b/src/models/logic/utxo.ts
@@ -485,47 +485,42 @@ export async function transferUTXO(
             output.get({ plain: true })
         );
         await Promise.all(
-            outputs!.map(
-                async (
-                    output: AssetTransferOutputAttribute,
-                    transactionOutputIndex: number
-                ) => {
-                    const recipient = getOwner(
-                        new H160(output.lockScriptHash),
-                        output.parameters,
-                        networkId
-                    );
-                    const assetType = new H160(output.assetType);
-                    const shardId = output.shardId;
-                    const lockScriptHash = new H160(output.lockScriptHash);
-                    const parameters = output.parameters;
-                    const quantity = new U64(output.quantity);
-                    const orderOnTransfer = (await transferAsset.getOrders()).find(
-                        o =>
-                            o
-                                .get({ plain: true })
-                                .outputIndices.includes(transactionOutputIndex)
-                    );
-                    const order =
-                        orderOnTransfer && (await orderOnTransfer.getOrder());
-                    const orderHash = order && new H256(order.get().orderHash);
-                    return createUTXO(
-                        recipient,
-                        {
-                            assetType,
-                            shardId,
-                            lockScriptHash,
-                            parameters,
-                            quantity,
-                            orderHash,
-                            transactionHash,
-                            transactionTracker,
-                            transactionOutputIndex
-                        },
-                        blockNumber
-                    );
-                }
-            )
+            outputs!.map(async (output: AssetTransferOutputAttribute) => {
+                const recipient = getOwner(
+                    new H160(output.lockScriptHash),
+                    output.parameters,
+                    networkId
+                );
+                const assetType = new H160(output.assetType);
+                const shardId = output.shardId;
+                const lockScriptHash = new H160(output.lockScriptHash);
+                const parameters = output.parameters;
+                const quantity = new U64(output.quantity);
+                const orderOnTransfer = (await transferAsset.getOrders()).find(
+                    o =>
+                        o
+                            .get({ plain: true })
+                            .outputIndices.includes(output.index)
+                );
+                const order =
+                    orderOnTransfer && (await orderOnTransfer.getOrder());
+                const orderHash = order && new H256(order.get().orderHash);
+                return createUTXO(
+                    recipient,
+                    {
+                        assetType,
+                        shardId,
+                        lockScriptHash,
+                        parameters,
+                        quantity,
+                        orderHash,
+                        transactionHash,
+                        transactionTracker,
+                        transactionOutputIndex: output.index
+                    },
+                    blockNumber
+                );
+            })
         );
         const inputs = await transferAsset.getInputs();
         if (inputs) {
@@ -656,7 +651,7 @@ export async function transferUTXO(
 
         const outputs = (await decomposeAsset.getOutputs())!;
         return await Promise.all(
-            outputs!.map((outputInst, transactionOutputIndex: number) => {
+            outputs!.map(outputInst => {
                 const output = outputInst.get({ plain: true });
                 const recipient = getOwner(
                     new H160(output.lockScriptHash),
@@ -678,7 +673,7 @@ export async function transferUTXO(
                         quantity,
                         transactionHash,
                         transactionTracker,
-                        transactionOutputIndex
+                        transactionOutputIndex: outputInst.get().index
                     },
                     blockNumber
                 );


### PR DESCRIPTION
Currently, Both transferAsset and decomposeAsset, which have the outputs field,
creates UTXOs with wrong transactionOutputIndex. This patch fixes it.

This patch also removes the unused argument.