### PR TITLE
Use DISTINCT for a transaction hash when counting transactions

### DIFF
--- a/src/models/logic/transaction.ts
+++ b/src/models/logic/transaction.ts
@@ -270,10 +270,12 @@ export async function getNumberOfPendingTransactions(params: {
     const { address, assetType, type } = params;
     const query = getPendingTransactionsQuery({ address, assetType, type });
     try {
-        return await models.Transaction.count({
+        return models.Transaction.count({
             where: {
                 [Sequelize.Op.and]: query
             },
+            distinct: true,
+            col: "hash",
             include: includeArray
         });
     } catch (err) {
@@ -519,10 +521,12 @@ export async function getNumberOfTransactions(params: {
         confirmThreshold
     });
     try {
-        return await models.Transaction.count({
+        return models.Transaction.count({
             where: {
                 [Sequelize.Op.and]: query
             },
+            distinct: true,
+            col: "hash",
             include: includeArray
         });
     } catch (err) {


### PR DESCRIPTION
This resolves https://github.com/CodeChain-io/codechain-indexer/issues/159

This fixes a bug, which is similar to the thing described in
1f99fd0eb13779a09cc88a2fbf4d84c222e0e955. When it comes to the count function,
the LEFT JOIN clause makes the result bigger than the actual number of
transactions.