### PR TITLE
Add serverTime field to the response of /api/status/sync

### DIFF
--- a/src/routers/status.ts
+++ b/src/routers/status.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { SERVICE_UNAVAILABLE } from "http-status-codes";
+import moment = require("moment");
 import { IndexerContext } from "../context";
 import * as BlockModel from "../models/logic/block";
 /**
@@ -140,7 +141,8 @@ export function handle(context: IndexerContext, router: Router) {
                     : 0,
                 indexedBlockHash: latestBlockInst
                     ? latestBlockInst.get().hash
-                    : null
+                    : null,
+                serverTime: moment().unix()
             });
         } catch (e) {
             const error = e as Error;


### PR DESCRIPTION
I add serverTime field to the response of /api/status/sync.
Explorer can use servertime after this patch. https://github.com/CodeChain-io/codechain-explorer/issues/88