### PR TITLE
Set the master account as the signer for regular key signed transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "migrate": "sequelize db:migrate",
     "start": "ts-node src/index.ts",
     "del": "ts-node script/deleteBlock.ts",
-    "test": "NODE_ENV=test mocha --exit -r ts-node/register --timeout 30000 --recursive \"test/**/*.spec.ts\"",
+    "test": "NODE_ENV=test mocha --exit -r ts-node/register --timeout 60000 --recursive \"test/**/*.spec.ts\"",
     "lint": "tslint -p . && prettier '{src,test,script}/**/*.{ts,js,json}' -l",
     "fmt": "tslint -p . --fix && prettier '{src,test,script}/**/*.{ts,js,json}' --write"
   },

--- a/src/migrations/20190418112715-add-set-regular-key-key-index.js
+++ b/src/migrations/20190418112715-add-set-regular-key-key-index.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const TABLE_NAME = "SetRegularKeys";
+const ATTRIBUTES = ["key"];
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+        return queryInterface.addIndex(TABLE_NAME, ATTRIBUTES, {
+            unique: false
+        });
+    },
+    down: (queryInterface, Sequelize) => {
+        return queryInterface.removeIndex(TABLE_NAME, ATTRIBUTES, {
+            force: true
+        });
+    }
+};

--- a/src/models/logic/transaction.ts
+++ b/src/models/logic/transaction.ts
@@ -694,8 +694,16 @@ function buildIncludeArray(params: {
 
 export async function getRegularKeyOwnerByPublicKey(
     pubkey: string,
-    options: { transaction?: Transaction }
+    options: { transaction?: Transaction; blockNumber?: number }
 ): Promise<string | null> {
+    const where: any =
+        options.blockNumber != null
+            ? {
+                  blockNumber: {
+                      [Sequelize.Op.lte]: options.blockNumber
+                  }
+              }
+            : undefined;
     const tx = await models.Transaction.findOne({
         include: [
             {
@@ -707,6 +715,7 @@ export async function getRegularKeyOwnerByPublicKey(
             }
         ],
         order: [["blockNumber", "DESC"], ["transactionIndex", "DESC"]],
+        where,
         transaction: options.transaction
     });
     if (tx == null) {

--- a/src/models/logic/utils/workerpool.ts
+++ b/src/models/logic/utils/workerpool.ts
@@ -7,6 +7,7 @@ import * as _ from "lodash";
 import * as workerpool from "workerpool";
 import { getApprovals, getTracker } from "./transaction";
 
+/* istanbul ignore next */
 const getSignersFromSignatures = (
     txs: { signature: string; message: string }[],
     networkId: string

--- a/src/models/logic/utils/workerpool.ts
+++ b/src/models/logic/utils/workerpool.ts
@@ -37,16 +37,17 @@ const getSignersFromPubKeyAndRegularKeyOwner = (
 
 export const getSigners = async (
     txs: SignedTransaction[],
-    options: { transaction?: Sequelize.Transaction }
+    options: { transaction?: Sequelize.Transaction; threshold?: number } = {}
 ): Promise<string[]> => {
-    if (txs.length < 400) {
+    const threshold = options.threshold == null ? 400 : options.threshold;
+    if (txs.length < threshold) {
         // NOTE: Don't create workerpool when there is a small number of transactions.
         return Promise.all(
             txs.map(async tx => {
                 const pubKey = tx.getSignerPublic().value;
                 const regularKeyOwner = await getRegularKeyOwnerByPublicKey(
                     pubKey,
-                    options
+                    { transaction: options.transaction }
                 );
                 if (regularKeyOwner != null) {
                     return regularKeyOwner;

--- a/src/models/logic/utils/workerpool.ts
+++ b/src/models/logic/utils/workerpool.ts
@@ -4,57 +4,115 @@ import {
 } from "codechain-sdk/lib/core/classes";
 import { blake160, recoverEcdsa } from "codechain-sdk/lib/utils";
 import * as _ from "lodash";
+import * as Sequelize from "sequelize";
 import * as workerpool from "workerpool";
+import { getRegularKeyOwnerByPublicKey } from "../transaction";
 import { getApprovals, getTracker } from "./transaction";
 
 /* istanbul ignore next */
-const getSignersFromSignatures = (
-    txs: { signature: string; message: string }[],
-    networkId: string
-) => {
+const getSignerPublicsFromSignatures = (
+    txs: { signature: string; message: string }[]
+): string[] => {
     // tslint:disable:no-shadowed-variable
-    const { recoverEcdsa, blake160 } = require("codechain-sdk/lib/utils");
+    const { recoverEcdsa } = require("codechain-sdk/lib/utils");
+    return txs.map(tx => recoverEcdsa(tx.message, tx.signature));
+};
+
+/* istanbul ignore next */
+const getSignersFromPubKeyAndRegularKeyOwner = (
+    params: { signerPubKey: string; regularKeyOwner: string }[],
+    networkId: string
+): string[] => {
+    // tslint:disable:no-shadowed-variable
     const { PlatformAddress } = require("codechain-sdk/lib/core/classes");
-    return txs.map(tx => {
-        const { message, signature } = tx;
-        const accountId = blake160(recoverEcdsa(message, signature));
-        return PlatformAddress.fromAccountId(accountId, {
-            networkId
-        }).toString();
+    return params.map(param => {
+        const { signerPubKey, regularKeyOwner } = param;
+        if (regularKeyOwner != null) {
+            return regularKeyOwner;
+        }
+
+        return PlatformAddress.fromPublic(signerPubKey, networkId);
     });
 };
 
 export const getSigners = async (
-    txs: SignedTransaction[]
+    txs: SignedTransaction[],
+    options: { transaction?: Sequelize.Transaction }
 ): Promise<string[]> => {
     if (txs.length < 400) {
         // NOTE: Don't create workerpool when there is a small number of transactions.
-        return txs.map(tx =>
-            tx
-                .getSignerAddress({
+        return Promise.all(
+            txs.map(async tx => {
+                const pubKey = tx.getSignerPublic().value;
+                const regularKeyOwner = await getRegularKeyOwnerByPublicKey(
+                    pubKey,
+                    options
+                );
+                if (regularKeyOwner != null) {
+                    return regularKeyOwner;
+                }
+                return PlatformAddress.fromPublic(pubKey, {
                     networkId: tx.unsigned.networkId()
-                })
-                .toString()
+                }).toString();
+            })
         );
     }
 
     const pool = workerpool.pool({
         nodeWorker: "auto"
     } as any);
-    const signer = await Promise.all(
-        _.chunk(txs, 100).map(chunk => {
-            return pool.exec(getSignersFromSignatures, [
-                chunk.map(tx => ({
-                    signature: tx.signature(),
-                    message: tx.unsigned.unsignedHash().toString()
-                })),
-                chunk[0].unsigned.networkId()
-            ]);
+    const networkId = txs[0].unsigned.networkId();
+    const signatureAndMessages = txs.map(tx => ({
+        signature: tx.signature(),
+        message: tx.unsigned.unsignedHash().toString()
+    }));
+    const signerPubKeys: string[][] = (await workerpool.Promise.all(
+        _.chunk(signatureAndMessages, 100).map(chunk => {
+            return pool.exec(getSignerPublicsFromSignatures, [chunk]);
         })
-    ).then(chunks => _.flatten(chunks));
+    )) as any;
+    const regularKeyOwnerAndPubKeys: [
+        string | null,
+        string
+    ][][] = await Promise.all(
+        signerPubKeys.map(async (signerPubKey: string[]) => {
+            return Promise.all(
+                signerPubKey.map(
+                    async (
+                        signerPubKey: string
+                    ): Promise<[string | null, string]> => {
+                        const regularKeyOwner = await getRegularKeyOwnerByPublicKey(
+                            signerPubKey,
+                            options
+                        );
+                        return [regularKeyOwner, signerPubKey];
+                    }
+                )
+            );
+        })
+    );
+
+    const chunks: string[][] = (await workerpool.Promise.all(
+        regularKeyOwnerAndPubKeys.map(
+            (
+                chunk: [string | null, string][]
+            ): workerpool.Promise<string[][]> => {
+                return pool.exec(getSignersFromPubKeyAndRegularKeyOwner, [
+                    chunk.map(([regularKeyOwner, signerPubKey]) => {
+                        return {
+                            regularKeyOwner,
+                            signerPubKey
+                        };
+                    }),
+                    networkId
+                ]);
+            }
+        )
+    )) as any; // The bug of workerpool type definition
+    const signers = _.flatten(chunks);
     // FIXME: Check if we need to await the terminate().
     pool.terminate();
-    return signer;
+    return signers;
 };
 
 // FIXME: Utilize multicore

--- a/test/set-regular-key.spec.ts
+++ b/test/set-regular-key.spec.ts
@@ -1,0 +1,193 @@
+import { expect } from "chai";
+import "mocha";
+import { SignedTransaction } from "codechain-sdk/lib/core/SignedTransaction";
+import * as AccountModel from "../src/models/logic/account";
+import * as Helper from "./helper";
+
+describe("set-regular-key", function() {
+    it("1 transaction after Set regular key", async function() {
+        await testPayAfterSetRegularKey(1);
+    });
+
+    it("3 transactions after Set regular key", async function() {
+        await testPayAfterSetRegularKey(3);
+    });
+
+    it("10 transactions after Set regular key", async function() {
+        await testPayAfterSetRegularKey(10);
+    });
+
+    it("100 transactions after Set regular key", async function() {
+        await testPayAfterSetRegularKey(100);
+    });
+
+    it("1000 transactions after Set regular key", async function() {
+        await testPayAfterSetRegularKey(1000);
+    });
+});
+
+async function prepareRegularKeyRegisteredAccount(
+    quantity: number,
+    masterPrivateKey: string,
+    regularPrivateKey: string
+) {
+    const masterAccountId = Helper.sdk.util
+        .getAccountIdFromPrivate(masterPrivateKey)
+        .toString();
+    const master = Helper.sdk.core.classes.PlatformAddress.fromAccountId(
+        masterAccountId,
+        {
+            networkId: Helper.sdk.networkId
+        }
+    ).toString();
+
+    {
+        const seq = await Helper.sdk.rpc.chain.getSeq(Helper.ACCOUNT_ADDRESS);
+        const signed = Helper.sdk.core
+            .createPayTransaction({
+                quantity,
+                recipient: master
+            })
+            .sign({
+                secret: Helper.ACCOUNT_SECRET,
+                fee: 10,
+                seq
+            });
+        const blockNumber = await Helper.sdk.rpc.chain.getBestBlockNumber();
+        await Helper.sdk.rpc.chain.sendSignedTransaction(signed);
+        await waitBlock(blockNumber + 1);
+        expect(await Helper.sdk.rpc.chain.getTransaction(signed.hash())).not
+            .null;
+    }
+
+    const key = Helper.sdk.util.getPublicFromPrivate(regularPrivateKey);
+    {
+        const seq = await Helper.sdk.rpc.chain.getSeq(master);
+        const signed = Helper.sdk.core
+            .createSetRegularKeyTransaction({ key })
+            .sign({
+                secret: masterPrivateKey,
+                fee: 10,
+                seq
+            });
+        const blockNumber = await Helper.sdk.rpc.chain.getBestBlockNumber();
+        await Helper.sdk.rpc.chain.sendSignedTransaction(signed);
+        await waitBlock(blockNumber + 1);
+        expect(await Helper.sdk.rpc.chain.getTransaction(signed.hash())).not
+            .null;
+    }
+}
+
+function createSignedPay(params: {
+    count: number;
+    quantity: number;
+    fee: number;
+    seq: number;
+    secret: string;
+}): SignedTransaction[] {
+    const { count, quantity, fee, seq, secret } = params;
+    const transactions = [];
+    for (let i = 0; i < count; i += 1) {
+        transactions.push(
+            Helper.sdk.core
+                .createPayTransaction({
+                    recipient: Helper.ACCOUNT_ADDRESS,
+                    quantity
+                })
+                .sign({
+                    secret,
+                    fee,
+                    seq: seq + i
+                })
+        );
+    }
+    return transactions;
+}
+
+async function testPayAfterSetRegularKey(countOfPayment: number) {
+    const masterPrivateKey = Helper.sdk.util.generatePrivateKey();
+    const masterAccountId = Helper.sdk.util
+        .getAccountIdFromPrivate(masterPrivateKey)
+        .toString();
+    const master = Helper.sdk.core.classes.PlatformAddress.fromAccountId(
+        masterAccountId,
+        {
+            networkId: Helper.sdk.networkId
+        }
+    ).toString();
+
+    const TOTAL_QUANTITY = 1_000_000_000;
+    const regularPrivateKey = Helper.sdk.util.generatePrivateKey();
+    const regularAccountId = Helper.sdk.util
+        .getAccountIdFromPrivate(regularPrivateKey)
+        .toString();
+    const regular = Helper.sdk.core.classes.PlatformAddress.fromAccountId(
+        regularAccountId,
+        {
+            networkId: Helper.sdk.networkId
+        }
+    ).toString();
+
+    await prepareRegularKeyRegisteredAccount(
+        TOTAL_QUANTITY,
+        masterPrivateKey,
+        regularPrivateKey
+    );
+
+    const blockNumber = await Helper.sdk.rpc.chain.getBestBlockNumber();
+    const seq = await Helper.sdk.rpc.chain.getSeq(master);
+
+    const quantity = 1000;
+    const fee = 100;
+    await Helper.sdk.rpc.devel.stopSealing();
+    const transactions = await createSignedPay({
+        seq,
+        fee,
+        secret: regularPrivateKey,
+        quantity,
+        count: countOfPayment
+    });
+    await Promise.all(
+        transactions.map(tx => Helper.sdk.rpc.chain.sendSignedTransaction(tx))
+    );
+    const lastHash = transactions[countOfPayment - 1].hash();
+    await Helper.sdk.rpc.devel.startSealing();
+    await waitBlock(blockNumber + 1);
+    expect(await Helper.sdk.rpc.chain.getBestBlockNumber()).equal(
+        blockNumber + 1
+    );
+    expect(await Helper.sdk.rpc.chain.containsTransaction(lastHash)).not.null;
+
+    const REMAIN = (
+        TOTAL_QUANTITY -
+        10 -
+        (fee + quantity) * countOfPayment
+    ).toString();
+
+    expect(await Helper.sdk.rpc.chain.getSeq(master)).equal(
+        seq + countOfPayment
+    );
+    expect((await Helper.sdk.rpc.chain.getBalance(master)).toString(10)).equal(
+        REMAIN
+    );
+    expect(await Helper.sdk.rpc.chain.getSeq(regular)).equal(0);
+    expect((await Helper.sdk.rpc.chain.getBalance(regular)).toString(10)).equal(
+        (0).toString()
+    );
+
+    await Helper.worker.sync();
+
+    const masterAccount = (await AccountModel.getByAddress(master))!;
+    expect(masterAccount).not.null;
+    expect(masterAccount.get("balance")).equal(REMAIN);
+    expect(masterAccount.get("seq")).equal(seq + countOfPayment);
+
+    const regularAccount = (await AccountModel.getByAddress(regular))!;
+    expect(regularAccount).be.null;
+}
+
+async function waitBlock(block: number) {
+    while ((await Helper.sdk.rpc.chain.getBestBlockNumber()) < block) {
+        await new Promise(resolve => setTimeout(resolve, 500));
+    }
+}


### PR DESCRIPTION
This PR fixes the bug that made the signer of the regular key signed transaction does not exist.

It can have a potential performance issue. I cannot run the test with more than 1000 transactions in a block. However, it can be the problem of jest. When I ran it with `yarn start`, the performance is not so bad.