### PR TITLE
Do not set the timeout per test

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "migrate": "sequelize db:migrate",
     "start": "ts-node src/index.ts",
     "del": "ts-node script/deleteBlock.ts",
-    "test": "NODE_ENV=test mocha --exit -r ts-node/register --timeout 5000 --recursive \"test/**/*.spec.ts\"",
+    "test": "NODE_ENV=test mocha --exit -r ts-node/register --timeout 30000 --recursive \"test/**/*.spec.ts\"",
     "lint": "tslint -p . && prettier '{src,test,script}/**/*.{ts,js,json}' -l",
     "fmt": "tslint -p . --fix && prettier '{src,test,script}/**/*.{ts,js,json}' --write"
   },

--- a/test/api/account.spec.ts
+++ b/test/api/account.spec.ts
@@ -18,8 +18,6 @@ describe("account-api", function() {
     let app: express.Express;
 
     before(async function() {
-        this.timeout("30s");
-
         await Helper.resetDb();
         await Helper.runExample("import-test-account");
         await Helper.worker.sync();
@@ -84,14 +82,12 @@ describe("account-api", function() {
     });
 
     it("api /account", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/account")
             .expect(200);
     });
 
     it("api /account with args", async function() {
-        this.timeout("30s");
         const itemsPerPage = 2;
         await request(app)
             .get(`/api/account?page=1&itemsPerPage=${itemsPerPage}`)
@@ -104,14 +100,12 @@ describe("account-api", function() {
     });
 
     it("api /account/count", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/account/count")
             .expect(200);
     });
 
     it("api /account/{address}", async function() {
-        this.timeout("30s");
         const address = "tccqyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqungah99";
         await request(app)
             .get(`/api/account/${address}`)

--- a/test/api/asset.spec.ts
+++ b/test/api/asset.spec.ts
@@ -21,8 +21,6 @@ describe("asset-api", function() {
     let app: express.Express;
 
     before(async function() {
-        this.timeout("30s");
-
         await Helper.resetDb();
         await Helper.runExample("import-test-account");
         await Helper.worker.sync();
@@ -93,14 +91,12 @@ describe("asset-api", function() {
     });
 
     it("api /utxo", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/utxo")
             .expect(200);
     });
 
     it("api /utxo with args", async function() {
-        this.timeout("30s");
         const address = aliceAddress;
         const assetType = mintTx.getMintedAsset().assetType;
         await request(app)
@@ -114,7 +110,6 @@ describe("asset-api", function() {
     });
 
     it("api /asset-scheme/{assetType}", async function() {
-        this.timeout("30s");
         const assetType = mintTx.getMintedAsset().assetType;
         await request(app)
             .get(`/api/asset-scheme/${assetType}`)
@@ -122,7 +117,6 @@ describe("asset-api", function() {
     });
 
     it("api /asset-image/{assetType}", async function() {
-        this.timeout("30s");
         const assetType = mintTx.getMintedAsset().assetType;
         await request(app)
             .get(`/api/asset-image/${assetType}`)
@@ -130,14 +124,12 @@ describe("asset-api", function() {
     });
 
     it("api /aggs-utxo", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/aggs-utxo")
             .expect(200);
     });
 
     it("api /aggs-utxo with args", async function() {
-        this.timeout("30s");
         const address = bobAddress;
         const assetType = mintTx.getMintedAsset().assetType;
         await request(app)
@@ -151,7 +143,6 @@ describe("asset-api", function() {
     });
 
     it("api /aggs-utxo/count", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/aggs-utxo/count")
             .expect(200)
@@ -161,7 +152,6 @@ describe("asset-api", function() {
     });
 
     it("api /aggs-utxo/count with args", async function() {
-        this.timeout("30s");
         const address = bobAddress;
         const assetType = mintTx.getMintedAsset().assetType;
         await request(app)
@@ -173,7 +163,6 @@ describe("asset-api", function() {
     });
 
     it("api /snapshot", async function() {
-        this.timeout("30s");
         const assetType = mintTx.getMintedAsset().assetType;
         const date = "2019-03-11";
         await request(app)

--- a/test/api/block.spec.ts
+++ b/test/api/block.spec.ts
@@ -17,8 +17,6 @@ describe("block-api", function() {
     let app: express.Express;
 
     before(async function() {
-        this.timeout("30s");
-
         await Helper.resetDb();
         await Helper.runExample("import-test-account");
         await Helper.worker.sync();
@@ -83,21 +81,18 @@ describe("block-api", function() {
     });
 
     it("api /block/latest", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/block/latest")
             .expect(200);
     });
 
     it("api /block/count", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/block/count")
             .expect(200);
     });
 
     it("api /block/count with args", async function() {
-        this.timeout("30s");
         const address = bobAddress;
         await request(app)
             .get(`/api/block/count?address=${address}`)
@@ -105,7 +100,6 @@ describe("block-api", function() {
     });
 
     it("api /block/{hashOrNumber}", async function() {
-        this.timeout("30s");
         const hash =
             "d9c2a05f4f1e53634f1f68a3560d419b53e1900c2e85ae77f0abf97954d9b66d";
         await request(app)
@@ -114,7 +108,6 @@ describe("block-api", function() {
     });
 
     it("api /block/{hashOrNumber}", async function() {
-        this.timeout("30s");
         const num = 1;
         await request(app)
             .get(`/api/block/${num}`)
@@ -122,14 +115,12 @@ describe("block-api", function() {
     });
 
     it("api /block", async function() {
-        this.timeout("30s");
         await request(app)
             .get(`/api/block`)
             .expect(200);
     });
 
     it("api /block with args", async function() {
-        this.timeout("30s");
         const address = "tccqyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhhn9p3";
         await request(app)
             .get(`/api/block?address=${address}`)

--- a/test/api/log.spec.ts
+++ b/test/api/log.spec.ts
@@ -17,8 +17,6 @@ describe("log-api", function() {
     let app: express.Express;
 
     before(async function() {
-        this.timeout("30s");
-
         await Helper.resetDb();
         await Helper.runExample("import-test-account");
         await Helper.worker.sync();
@@ -83,7 +81,6 @@ describe("log-api", function() {
     });
 
     it("api /log/count", async function() {
-        this.timeout("30s");
         const date = "2000-01-01";
 
         await request(app)
@@ -92,7 +89,6 @@ describe("log-api", function() {
     });
 
     it("api /log/miners", async function() {
-        this.timeout("30s");
         const date = "2000-01-01";
 
         await request(app)

--- a/test/api/status.spec.ts
+++ b/test/api/status.spec.ts
@@ -18,8 +18,6 @@ describe("status-api", function() {
     let app: express.Express;
 
     before(async function() {
-        this.timeout("30s");
-
         await Helper.resetDb();
         await Helper.runExample("import-test-account");
         await Helper.worker.sync();
@@ -84,14 +82,12 @@ describe("status-api", function() {
     });
 
     it("api /ping", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/ping")
             .expect(200);
     });
 
     it("api /ping rpc fail", async function() {
-        this.timeout("30s");
         const pingStub = sinon.stub(context.sdk.rpc.node, "ping");
         pingStub.rejects(Error("ECONNREFUSED"));
 
@@ -103,14 +99,12 @@ describe("status-api", function() {
     });
 
     it("api /status/codechain", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/status/codechain")
             .expect(200);
     });
 
     it("api /status/codechain rpc fail", async function() {
-        this.timeout("30s");
         const pingStub = sinon.stub(context.sdk.rpc.node, "getNodeVersion");
         pingStub.rejects(Error("ECONNREFUSED"));
         await request(app)
@@ -121,14 +115,12 @@ describe("status-api", function() {
     });
 
     it("api /status/sync", async function() {
-        this.timeout("30s");
         request(app)
             .get("/api/status/sync")
             .expect(200);
     });
 
     it("api /status/sync rpc fail", async function() {
-        this.timeout("30s");
         const getBestBlockNumberStub = sinon.stub(
             context.sdk.rpc.chain,
             "getBestBlockNumber"

--- a/test/api/transaction.spec.ts
+++ b/test/api/transaction.spec.ts
@@ -25,7 +25,6 @@ describe("transaction-api", function() {
     let app: express.Express;
 
     before(async function() {
-        this.timeout("30s");
         await Helper.resetDb();
         await Helper.runExample("import-test-account");
         await Helper.worker.sync();
@@ -120,14 +119,12 @@ describe("transaction-api", function() {
     });
 
     it("api /tx", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/tx")
             .expect(200);
     });
 
     it("api /tx rpc fail", async function() {
-        this.timeout("30s");
         const getBestBlockNumberStub = sinon.stub(
             context.sdk.rpc.chain,
             "getBestBlockNumber"
@@ -146,7 +143,6 @@ describe("transaction-api", function() {
     });
 
     it("api /tx with args", async function() {
-        this.timeout("30s");
         const assetType = mintRubyTx.getMintedAsset().assetType;
         const tracker = mintRubyTx.tracker().value;
         await request(app)
@@ -160,7 +156,6 @@ describe("transaction-api", function() {
     });
 
     it("api /tx/count", async function() {
-        this.timeout("30s");
         await request(app)
             .get("/api/tx/count")
             .expect(200)
@@ -168,7 +163,6 @@ describe("transaction-api", function() {
     });
 
     it("api /tx/count with args", async function() {
-        this.timeout("30s");
         const assetType = mintRubyTx.getMintedAsset().assetType;
         const tracker = mintRubyTx.tracker().value;
 
@@ -181,21 +175,18 @@ describe("transaction-api", function() {
     });
 
     it("api /tx/{hash}", async function() {
-        this.timeout("30s");
         await request(app)
             .get(`/api/tx/${transferTxHash}`)
             .expect(200);
     });
 
     it("api /pending-tx", async function() {
-        this.timeout("30s");
         await request(app)
             .get(`/api/pending-tx`)
             .expect(200);
     });
 
     it.skip("api /pending-tx with args", async function() {
-        this.timeout("30s");
         const address = aliceAddress.value;
         const assetType = mintEmeraldTx.getMintedAsset().assetType;
         await request(app)
@@ -206,7 +197,6 @@ describe("transaction-api", function() {
     });
 
     it("api /pending-tx/count", async function() {
-        this.timeout("30s");
         await request(app)
             .get(`/api/pending-tx/count`)
             .expect(200)
@@ -214,7 +204,6 @@ describe("transaction-api", function() {
     });
 
     it.skip("api /pending-tx/count with args", async function() {
-        this.timeout("30s");
         const address = aliceAddress.value;
         const assetType = mintEmeraldTx.getMintedAsset().assetType;
         await request(app)

--- a/test/log.spec.ts
+++ b/test/log.spec.ts
@@ -10,8 +10,6 @@ let txLogCount = 0;
 
 describe("log", function() {
     before(async function() {
-        this.timeout("60s");
-
         await Helper.resetDb();
         const date = moment()
             .utc()

--- a/test/pending-tx.spec.ts
+++ b/test/pending-tx.spec.ts
@@ -19,8 +19,6 @@ describe("pending-tx", function() {
     });
 
     it("Check pending transactions", async function() {
-        this.timeout("25s");
-
         await Helper.sdk.rpc.devel.stopSealing();
         let pendingTx;
         try {

--- a/test/snapshot.spec.ts
+++ b/test/snapshot.spec.ts
@@ -12,8 +12,6 @@ describe("snapshot", function() {
     let assetType: H256;
 
     beforeEach(async function() {
-        this.timeout("30s");
-
         // Sync the genesis block.
         await Helper.resetDb();
         await Helper.worker.sync();
@@ -55,8 +53,6 @@ describe("snapshot synchronized", function() {
     let assetType: H256;
 
     before(async function() {
-        this.timeout("30s");
-
         // Sync the genesis block.
         await Helper.resetDb();
         await Helper.worker.sync();

--- a/test/worker.spec.ts
+++ b/test/worker.spec.ts
@@ -18,7 +18,6 @@ describe("worker", function() {
     });
 
     it("Sync block test", async function() {
-        this.timeout("30s");
         const beforeLatestBlockInst = await BlockModel.getLatestBlock();
 
         await Helper.worker.sync();
@@ -44,7 +43,6 @@ describe("worker", function() {
     });
 
     it.skip("Sync account test", async function() {
-        this.timeout("30s");
         const genesisAccounts: string[] = await Helper.sdk.rpc.sendRpcRequest(
             "chain_getGenesisAccounts",
             []


### PR DESCRIPTION
The most time consuming part of the tests is synchronizing the db with
the chain, and it depends on the chain. In other words, the test needs
a longer time when the chain has more data. So set the timeout per test
is meaningless in the most case.

This patch makes `yarn test` sets a global timeout instead of setting
the timeout per tests.