### PR TITLE
Fix the wrong argument passing when calling PlatformAddress.fromPublic

### DIFF
--- a/src/models/logic/utils/workerpool.ts
+++ b/src/models/logic/utils/workerpool.ts
@@ -31,7 +31,9 @@ const getSignersFromPubKeyAndRegularKeyOwner = (
             return regularKeyOwner;
         }
 
-        return PlatformAddress.fromPublic(signerPubKey, networkId);
+        return PlatformAddress.fromPublic(signerPubKey, {
+            networkId
+        }).toString();
     });
 };
 


### PR DESCRIPTION
It was hard to find because this function was called in the worker pool.