### PR TITLE
Add the blockNumber index to the AddressLogs table

### DIFF
--- a/src/migrations/20191111091152-add-address-log-index-block-number.js
+++ b/src/migrations/20191111091152-add-address-log-index-block-number.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.addIndex("AddressLogs", ["blockNumber"]);
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        await queryInterface.removeIndex("AddressLogs", ["blockNumber"]);
+    }
+};


### PR DESCRIPTION
Here is the slow query log.

The cause of the slow indexing might be this one.

```
2019-11-11 09:24:05.662 UTC [2831] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1643.751 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266220;
2019-11-11 09:24:07.726 UTC [2829] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1686.140 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266221;
2019-11-11 09:24:09.692 UTC [2828] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1647.664 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266222;
2019-11-11 09:24:11.690 UTC [2827] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1656.125 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266223;
2019-11-11 09:24:15.697 UTC [2827] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1676.752 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266224;
2019-11-11 09:24:17.725 UTC [9849] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1661.164 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266225;
2019-11-11 09:24:19.672 UTC [2831] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1651.496 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266226;
2019-11-11 09:24:23.701 UTC [2831] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1660.593 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266227;
2019-11-11 09:24:25.678 UTC [2830] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1656.865 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266228;
2019-11-11 09:24:27.689 UTC [2829] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1654.394 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266229;
2019-11-11 09:24:29.669 UTC [2828] indexer-user@codechain-indexer-corgi-2 LOG:  duration: 1635.470 ms  statement: SELECT "address" FROM "AddressLogs" AS "AddressLog" WHERE "AddressLog"."blockNumber" = 2266230;
```