### PR TITLE
Change the address index of the CCCChanges table

### DIFF
--- a/src/migrations/20191112091700-add-ccc-changes-index-address-block-number-id.js
+++ b/src/migrations/20191112091700-add-ccc-changes-index-address-block-number-id.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const TABLE_NAME = "CCCChanges";
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.removeIndex(TABLE_NAME, "ccc_changes_address");
+        await queryInterface.addIndex(
+            TABLE_NAME,
+            ["address", "blockNumber", "id"],
+            {
+                name: "ccc_changes_address_block_number_id",
+                unique: true
+            }
+        );
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        await queryInterface.removeIndex(
+            TABLE_NAME,
+            "ccc_changes_address_block_number_id"
+        );
+        await queryInterface.addIndex(TABLE_NAME, ["address"], {
+            name: "ccc_changes_address",
+            unique: false
+        });
+    }
+};


### PR DESCRIPTION
The current address index is not used in the query for the balance history of
an address.

It fixes a part of https://github.com/CodeChain-io/codechain-indexer/issues/314.