### PR TITLE
Use index in the UTXO query

### DIFF
--- a/src/migrations/20191114095633-add-tx-index-to-utxo.js
+++ b/src/migrations/20191114095633-add-tx-index-to-utxo.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.addColumn("UTXOs", "transactionIndex", {
+            type: Sequelize.INTEGER
+        });
+
+        await queryInterface.sequelize.query(
+            `UPDATE "UTXOs" SET "transactionIndex" = (SELECT "Transactions"."transactionIndex" FROM "Transactions" WHERE hash="UTXOs"."transactionHash")`
+        );
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        return queryInterface.removeColumn("UTXOs", "transactionIndex");
+    }
+};

--- a/src/migrations/20191114103355-change-utxo-table-index.js
+++ b/src/migrations/20191114103355-change-utxo-table-index.js
@@ -1,0 +1,58 @@
+"use strict";
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.removeIndex("UTXOs", "u_t_x_os_address_id");
+        await queryInterface.removeIndex(
+            "UTXOs",
+            "UTXOs_assetType_usedBlockNumber"
+        );
+
+        await queryInterface.addIndex("UTXOs", [
+            "address",
+            "blockNumber",
+            "transactionIndex",
+            "transactionOutputIndex"
+        ]);
+        await queryInterface.addIndex("UTXOs", [
+            "assetType",
+            "blockNumber",
+            "transactionIndex",
+            "transactionOutputIndex"
+        ]);
+        await queryInterface.addIndex("UTXOs", [
+            "address",
+            "assetType",
+            "blockNumber",
+            "transactionIndex",
+            "transactionOutputIndex"
+        ]);
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        await queryInterface.removeIndex("UTXOs", [
+            "address",
+            "blockNumber",
+            "transactionIndex",
+            "transactionOutputIndex"
+        ]);
+        await queryInterface.removeIndex("UTXOs", [
+            "assetType",
+            "blockNumber",
+            "transactionIndex",
+            "transactionOutputIndex"
+        ]);
+        await queryInterface.removeIndex("UTXOs", [
+            "address",
+            "assetType",
+            "blockNumber",
+            "transactionIndex",
+            "transactionOutputIndex"
+        ]);
+        await queryInterface.addIndex("UTXOs", ["address", "id"]);
+        await queryInterface.addIndex("UTXOs", {
+            fields: ["assetType", "usedBlockNumber"],
+            name: "UTXOs_assetType_usedBlockNumber"
+        });
+    }
+};

--- a/src/models/logic/transaction.ts
+++ b/src/models/logic/transaction.ts
@@ -26,7 +26,7 @@ import { strip0xPrefix } from "./utils/format";
 import { fullIncludeArray } from "./utils/includeArray";
 import { getTracker, isAssetTransactionType } from "./utils/transaction";
 import { getApprovers, getSigners } from "./utils/workerpool";
-import { transferUTXO } from "./utxo";
+import { setUTXOTransactionIndex, transferUTXO } from "./utxo";
 import { createWrapCCC } from "./wrapCCC";
 
 export async function tryUpdateTransaction(
@@ -42,6 +42,13 @@ export async function tryUpdateTransaction(
         if (instance == null) {
             return null;
         }
+
+        await setUTXOTransactionIndex(
+            tx.hash().toString(),
+            tx.transactionIndex!,
+            options
+        );
+
         return instance.update(
             {
                 blockNumber: tx.blockNumber,

--- a/src/models/logic/utxo.ts
+++ b/src/models/logic/utxo.ts
@@ -262,7 +262,11 @@ export async function getUTXO(params: {
             where: {
                 [Sequelize.Op.and]: query
             },
-            order: [["id", "DESC"]],
+            order: [
+                ["blockNumber", "DESC"],
+                ["transactionIndex", "DESC"],
+                ["transactionOutputIndex", "DESC"]
+            ],
             limit: itemsPerPage!,
             offset: (page! - 1) * itemsPerPage!,
             include: includeArray

--- a/src/models/utxo.ts
+++ b/src/models/utxo.ts
@@ -17,6 +17,7 @@ export interface UTXOAttribute {
     usedBlockNumber?: number | null;
     assetScheme: AssetSchemeAttribute;
     blockNumber: number;
+    transactionIndex: number | null;
 }
 
 export interface UTXOInstance extends Sequelize.Instance<UTXOAttribute> {}
@@ -104,6 +105,10 @@ export default (
             },
             blockNumber: {
                 allowNull: false,
+                type: DataTypes.INTEGER
+            },
+            transactionIndex: {
+                allowNull: true,
                 type: DataTypes.INTEGER
             },
             usedBlockNumber: {


### PR DESCRIPTION
The indexer should sort UTXOs after queries. Sorting results by the `id` field is not a good option. Let's think about a UTXO that is created by a pending transaction. It's ` id` field could be lower than UTXOs created by mined transactions.

Using [`blockNumber`, `transactionIndex`, and `transactionOutputIndex`] makes a total order.

This PR makes the UTXO query to use the total order.

This PR fixes #318.