### PR TITLE
Pre-calculate the quantity of assets users have

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ services:
   - docker
   - postgresql
 addons:
-  postgresql: "9.4"
+  postgresql: "9.5"
 cache: yarn

--- a/src/migrations/20191115032739-add-aggs-utxo-table.js
+++ b/src/migrations/20191115032739-add-aggs-utxo-table.js
@@ -15,7 +15,12 @@ module.exports = {
             },
             assetType: {
                 allowNull: false,
-                type: Sequelize.STRING
+                type: Sequelize.STRING,
+                onDelete: "CASCADE",
+                references: {
+                    model: "AssetSchemes",
+                    key: "assetType"
+                }
             },
             totalAssetQuantity: {
                 allowNull: false,
@@ -39,6 +44,11 @@ module.exports = {
 
         await queryInterface.addIndex("AggsUTXOs", {
             fields: ["address", "assetType"],
+            unique: true
+        });
+
+        await queryInterface.addIndex("AggsUTXOs", {
+            fields: ["assetType", "address"],
             unique: true
         });
 

--- a/src/migrations/20191115032739-add-aggs-utxo-table.js
+++ b/src/migrations/20191115032739-add-aggs-utxo-table.js
@@ -1,0 +1,96 @@
+"use strict";
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.createTable("AggsUTXOs", {
+            id: {
+                allowNull: false,
+                autoIncrement: true,
+                primaryKey: true,
+                type: Sequelize.BIGINT
+            },
+            address: {
+                allowNull: false,
+                type: Sequelize.STRING
+            },
+            assetType: {
+                allowNull: false,
+                type: Sequelize.STRING
+            },
+            totalAssetQuantity: {
+                allowNull: false,
+                type: Sequelize.BIGINT,
+                defaultValue: 0
+            },
+            utxoQuantity: {
+                allowNull: false,
+                type: Sequelize.BIGINT,
+                defaultValue: 0
+            },
+            createdAt: {
+                allowNull: false,
+                type: Sequelize.DATE
+            },
+            updatedAt: {
+                allowNull: false,
+                type: Sequelize.DATE
+            }
+        });
+
+        await queryInterface.addIndex("AggsUTXOs", {
+            fields: ["address", "assetType"],
+            unique: true
+        });
+
+        await queryInterface.sequelize.query(`
+        CREATE FUNCTION utxos_trigger_function() RETURNS trigger
+        LANGUAGE plpgsql
+            as
+            $$
+                BEGIN
+                    IF (TG_OP = 'INSERT') THEN
+                        IF NEW."usedBlockNumber" IS NULL THEN
+                            INSERT INTO "AggsUTXOs"("assetType", address, "totalAssetQuantity", "utxoQuantity", "createdAt", "updatedAt") VALUES(NEW."assetType", NEW.address, NEW.quantity, 1, NOW(), NOW())
+                            ON CONFLICT ("assetType", "address") DO UPDATE SET "totalAssetQuantity"="AggsUTXOs"."totalAssetQuantity"+NEW."quantity", "utxoQuantity"="AggsUTXOs"."utxoQuantity"+1;
+                        END IF;
+                        return NEW;
+                    ELSEIF (TG_OP = 'UPDATE') THEN
+                        IF OLD."usedBlockNumber" IS NULL THEN
+                            UPDATE "AggsUTXOs" SET "totalAssetQuantity"="totalAssetQuantity"-OLD.quantity, "utxoQuantity"="utxoQuantity"-1, "updatedAt"=NOW() WHERE "AggsUTXOs".address=OLD.address AND "AggsUTXOs"."assetType"=OLD."assetType";
+                        END IF;
+                        IF NEW."usedBlockNumber" IS NULL THEN
+                            INSERT INTO "AggsUTXOs"("assetType", address, "totalAssetQuantity", "utxoQuantity", "createdAt", "updatedAt") VALUES(NEW."assetType", NEW.address, NEW.quantity, 1, NOW(), NOW())
+                            ON CONFLICT ("assetType", "address") DO UPDATE SET "totalAssetQuantity"="AggsUTXOs"."totalAssetQuantity"+NEW.quantity, "utxoQuantity"="AggsUTXOs"."utxoQuantity"+1;
+                        END IF;
+                        RETURN NEW;
+                    ELSEIF (TG_OP = 'DELETE') THEN
+                        IF OLD."usedBlockNumber" IS NULL THEN
+                            UPDATE "AggsUTXOs" SET "totalAssetQuantity"="totalAssetQuantity"-OLD.quantity, "utxoQuantity"="utxoQuantity"-1, "updatedAt"=NOW() WHERE "AggsUTXOs".address=OLD.address AND "AggsUTXOs"."assetType"=OLD."assetType";
+                        END IF;
+                        return OLD;
+                    END IF;
+                END;
+            $$;`);
+        await queryInterface.sequelize.query(`
+        CREATE TRIGGER utxos_trigger
+        AFTER INSERT OR UPDATE OR DELETE
+           ON "UTXOs"
+           FOR EACH ROW
+               EXECUTE PROCEDURE utxos_trigger_function()
+        `);
+
+        await queryInterface.sequelize.query(`
+            INSERT INTO "AggsUTXOs"("assetType", "address", "totalAssetQuantity", "utxoQuantity", "createdAt", "updatedAt") SELECT "assetType", "address", SUM("quantity") as "totalAssetQuantity", COUNT(*) as "utxoQuantity", NOW(), NOW() FROM "UTXOs" GROUP BY "assetType", "address"
+        `);
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        await queryInterface.dropTable("AggsUTXOs");
+        await queryInterface.sequelize.query(
+            `DROP TRIGGER "utxos_trigger" ON "UTXOs"`
+        );
+        await queryInterface.sequelize.query(
+            "DROP FUNCTION utxos_trigger_function()"
+        );
+    }
+};

--- a/src/models/aggsUTXO.ts
+++ b/src/models/aggsUTXO.ts
@@ -1,0 +1,67 @@
+import * as Sequelize from "sequelize";
+
+export interface AggsUTXOAttribute {
+    id?: string;
+    address: string;
+    assetType: string;
+    totalAssetQuantity: string;
+    utxoQuantity: string;
+}
+
+export interface AggsUTXOInstance
+    extends Sequelize.Instance<AggsUTXOAttribute> {}
+
+export default (
+    sequelize: Sequelize.Sequelize,
+    DataTypes: Sequelize.DataTypes
+) => {
+    const AggsUTXO = sequelize.define(
+        "AggsUTXO",
+        {
+            id: {
+                allowNull: false,
+                autoIncrement: true,
+                primaryKey: true,
+                type: DataTypes.BIGINT
+            },
+            address: {
+                allowNull: false,
+                type: DataTypes.STRING
+            },
+            assetType: {
+                allowNull: false,
+                type: DataTypes.STRING,
+                validate: {
+                    is: ["^[a-f0-9]{40}$"]
+                }
+            },
+            totalAssetQuantity: {
+                allowNull: false,
+                type: DataTypes.BIGINT
+            },
+            utxoQuantity: {
+                allowNull: false,
+                type: DataTypes.BIGINT
+            },
+            createdAt: {
+                allowNull: false,
+                type: DataTypes.DATE
+            },
+            updatedAt: {
+                allowNull: false,
+                type: DataTypes.DATE
+            }
+        },
+        {}
+    );
+
+    AggsUTXO.associate = models => {
+        AggsUTXO.belongsTo(models.AssetScheme, {
+            foreignKey: "assetType",
+            as: "assetScheme",
+            onDelete: "CASCADE"
+        });
+    };
+
+    return AggsUTXO;
+};

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -5,6 +5,7 @@ import * as Sequelize from "sequelize";
 import { IndexerConfig } from "../config";
 import { AccountAttribtue, AccountInstance } from "./account";
 import { AddressLogAttribute, AddressLogInstance } from "./addressLog";
+import { AggsUTXOAttribute, AggsUTXOInstance } from "./aggsUTXO";
 import { AssetImageAttribute, AssetImageInstance } from "./assetimage";
 import { AssetSchemeAttribute, AssetSchemeInstance } from "./assetscheme";
 import {
@@ -80,6 +81,7 @@ models.Sequelize = sequelize;
 interface DB {
     sequelize: Sequelize.Sequelize;
     Sequelize: Sequelize.SequelizeStatic;
+    AggsUTXO: Sequelize.Model<AggsUTXOInstance, AggsUTXOAttribute>;
     Block: Sequelize.Model<BlockInstance, BlockAttribute>;
     Transaction: Sequelize.Model<TransactionInstance, TransactionAttribute>;
     MintAsset: Sequelize.Model<MintAssetInstance, MintAssetAttribute>;

--- a/src/models/logic/aggsUTXO.ts
+++ b/src/models/logic/aggsUTXO.ts
@@ -1,0 +1,94 @@
+import { H160 } from "codechain-primitives";
+import * as Sequelize from "sequelize";
+import models from "..";
+import * as Exception from "../../exception";
+
+export async function getByAddress(params: {
+    address: string;
+    assetType?: H160 | null;
+    page?: number | null;
+    itemsPerPage?: number | null;
+}) {
+    const { address, assetType, page = 1, itemsPerPage = 15 } = params;
+    const query: any = getAggsUTXOQuery({
+        address,
+        assetType
+    });
+
+    const includeArray: any = [
+        {
+            as: "assetScheme",
+            model: models.AssetScheme
+        }
+    ];
+
+    try {
+        return await models.AggsUTXO.findAll({
+            where: {
+                [Sequelize.Op.and]: query
+            },
+            order: [["address", "DESC"], ["assetType", "DESC"]],
+            limit: itemsPerPage!,
+            offset: (page! - 1) * itemsPerPage!,
+            include: includeArray
+        });
+    } catch (err) {
+        console.error(err);
+        throw Exception.DBError();
+    }
+}
+
+export async function getByAssetType(params: {
+    assetType: H160;
+    address?: string | null;
+    page?: number | null;
+    itemsPerPage?: number | null;
+}) {
+    const { address, assetType, page = 1, itemsPerPage = 15 } = params;
+    const query: any = getAggsUTXOQuery({
+        address,
+        assetType
+    });
+
+    const includeArray: any = [
+        {
+            as: "assetScheme",
+            model: models.AssetScheme
+        }
+    ];
+
+    try {
+        return await models.AggsUTXO.findAll({
+            where: {
+                [Sequelize.Op.and]: query
+            },
+            order: [["assetType", "DESC"], ["address", "DESC"]],
+            limit: itemsPerPage!,
+            offset: (page! - 1) * itemsPerPage!,
+            include: includeArray
+        });
+    } catch (err) {
+        console.error(err);
+        throw Exception.DBError();
+    }
+}
+
+function getAggsUTXOQuery(params: {
+    address?: string | null;
+    assetType?: H160 | null;
+}) {
+    const { address, assetType } = params;
+    const query = [];
+    if (address) {
+        query.push({
+            address
+        });
+    }
+    if (assetType) {
+        query.push({
+            assetType: assetType.value
+        });
+    }
+
+    return query;
+}

--- a/test/api/asset.spec.ts
+++ b/test/api/asset.spec.ts
@@ -1,6 +1,7 @@
 import * as bodyParser from "body-parser";
 import { expect } from "chai";
 import * as express from "express";
+import * as _ from "lodash";
 import "mocha";
 import * as request from "supertest";
 
@@ -123,23 +124,67 @@ describe("asset-api", function() {
             .expect(200);
     });
 
-    it("api /aggs-utxo", async function() {
-        await request(app)
-            .get("/api/aggs-utxo")
-            .expect(200);
-    });
-
-    it("api /aggs-utxo with args", async function() {
-        const address = bobAddress;
+    it("api /aggs-utxo with assetType args", async function() {
         const assetType = mintTx.getMintedAsset().assetType;
         await request(app)
             .get(
-                `/api/aggs-utxo?address=${address}&assetType=${assetType}&page=1&itemsPerPage=1&onlyConfirmed=true&confirmThreshold=0&sync=true`
+                `/api/aggs-utxo?assetType=${assetType}&page=1&itemsPerPage=5&onlyConfirmed=true&confirmThreshold=0&sync=true`
             )
             .expect(200)
-            .expect(res =>
-                expect(Object.keys(JSON.parse(res.text)).length).equal(1)
-            );
+            .expect(res => {
+                const aggsUTXOs = JSON.parse(res.text);
+                expect(aggsUTXOs.length).equal(2);
+                const bobAggs = _.find(
+                    aggsUTXOs,
+                    agg => agg.address === bobAddress
+                );
+                const aliceAggs = _.find(
+                    aggsUTXOs,
+                    agg => agg.address === aliceAddress.toString()
+                );
+                expect(bobAggs.totalAssetQuantity).equal("3000");
+                expect(bobAggs.utxoQuantity).equal("2");
+                expect(aliceAggs.totalAssetQuantity).equal("7000");
+                expect(aliceAggs.utxoQuantity).equal("1");
+            });
+    });
+
+    it("api /aggs-utxo with address args", async function() {
+        const address = bobAddress;
+        await request(app)
+            .get(
+                `/api/aggs-utxo?address=${address}&page=1&itemsPerPage=5&onlyConfirmed=true&confirmThreshold=0&sync=true`
+            )
+            .expect(200)
+            .expect(res => {
+                const aggsUTXOs = JSON.parse(res.text);
+                const aggs = _.filter(
+                    aggsUTXOs,
+                    agg => agg.address === bobAddress
+                );
+                expect(aggs.length).equal(aggsUTXOs.length);
+                // This test queries 5 UTXO aggregations.
+                // If we run this test several times, the aggsUTXOs variable may contain previous test results.
+                // We can't add any assertions on the results.
+            });
+    });
+
+    it("api /aggs-utxo with args", async function() {
+        const address = aliceAddress.toString();
+        const assetType = mintTx.getMintedAsset().assetType;
+        await request(app)
+            .get(
+                `/api/aggs-utxo?address=${address}&assetType=${assetType}&page=1&itemsPerPage=5&onlyConfirmed=true&confirmThreshold=0&sync=true`
+            )
+            .expect(200)
+            .expect(res => {
+                const aggsUTXOs = JSON.parse(res.text);
+                expect(aggsUTXOs.length).equal(1);
+                expect(aggsUTXOs[0].assetType).equal(assetType.toString());
+                expect(aggsUTXOs[0].address).equal(address);
+                expect(aggsUTXOs[0].totalAssetQuantity).equal("7000");
+                expect(aggsUTXOs[0].utxoQuantity).equal("1");
+            });
     });
 
     it("api /aggs-utxo/count", async function() {


### PR DESCRIPTION
Users who use a wallet want to know which amount of assets they have. The indexer was calculating the data using an aggregation query. The aggregation query was slow as the aggregation query should scan the UTXOs.

To make the query faster, we can make a table that has pre-calculated asset amounts.

This PR fixes #321.