### PR TITLE
Calculate firstEvaluatedKey and lastEvaluatedKey correctly

### DIFF
--- a/src/routers/asset.ts
+++ b/src/routers/asset.ts
@@ -172,8 +172,6 @@ export function handle(context: IndexerContext, router: Router) {
                     confirmThreshold
                 });
                 const utxo = utxoInsts.map(inst => inst.get({ plain: true }));
-                const firstItem = utxo[0];
-                const lastItem = utxo[utxo.length - 1];
 
                 res.json(
                     createPaginationResult({
@@ -181,15 +179,8 @@ export function handle(context: IndexerContext, router: Router) {
                             firstEvaluatedKey,
                             lastEvaluatedKey
                         },
-                        result: {
-                            data: utxo,
-                            firstEvaluatedKey: firstItem
-                                ? UTXOModel.createUTXOEvaluatedKey(firstItem)
-                                : null,
-                            lastEvaluatedKey: lastItem
-                                ? UTXOModel.createUTXOEvaluatedKey(lastItem)
-                                : null
-                        },
+                        rows: utxo,
+                        getEvaluatedKey: UTXOModel.createUTXOEvaluatedKey,
                         itemsPerPage
                     })
                 );


### PR DESCRIPTION
The indexer queries DB one more row than a user requested. And the
indexer uses the additional row to let the user know whether there is
the next page or not.

The indexer should calculate firstEvaluatedKey and lastEvaluatedKey
without the additional row.

Before this commit, the indexer calculates evaluated keys before
removing the additional row.

After this commit, the indexer calculates evaluated keys after
removing the additional row.