### PR TITLE
Use an index to find rows in the next page in the AggsUTXO query

### DIFF
--- a/src/models/logic/utxo.ts
+++ b/src/models/logic/utxo.ts
@@ -3,6 +3,7 @@ import * as Sequelize from "sequelize";
 import models from "..";
 import * as Exception from "../../exception";
 import { utxoPagination } from "../../routers/pagination";
+import { AggsUTXOAttribute } from "../aggsUTXO";
 import { AssetSchemeAttribute } from "../assetscheme";
 import { TransactionInstance } from "../transaction";
 import { AssetTransferOutput } from "../transferAsset";
@@ -309,31 +310,55 @@ export function createUTXOEvaluatedKey(utxo: UTXOAttribute): string {
     ]);
 }
 
+export function createAggsUTXOEvaluatedKey(
+    aggs: AggsUTXOAttribute,
+    order: "assetType" | "address"
+): string {
+    return JSON.stringify([
+        order === "assetType" ? aggs.assetType : aggs.address
+    ]);
+}
+
 export async function getAggsUTXO(params: {
+    order: "assetType" | "address";
     address?: string | null;
     assetType?: H160 | null;
     shardId?: number | null;
     page?: number | null;
     itemsPerPage?: number | null;
+    firstEvaluatedKey?: [number] | null;
+    lastEvaluatedKey?: [number] | null;
     onlyConfirmed?: boolean | null;
     confirmThreshold?: number | null;
 }) {
-    const { address, assetType, page = 1, itemsPerPage = 15 } = params;
+    const {
+        order,
+        address,
+        assetType,
+        page = 1,
+        itemsPerPage = 15,
+        firstEvaluatedKey,
+        lastEvaluatedKey
+    } = params;
 
     try {
-        if (address) {
+        if (order === "assetType") {
             return await AggsUTXOModel.getByAddress({
-                address,
+                address: address!,
                 assetType,
                 page,
-                itemsPerPage
+                itemsPerPage,
+                firstEvaluatedKey,
+                lastEvaluatedKey
             });
-        } else if (assetType) {
+        } else if (order === "address") {
             return await AggsUTXOModel.getByAssetType({
                 address,
-                assetType,
+                assetType: assetType!,
                 page,
-                itemsPerPage
+                itemsPerPage,
+                firstEvaluatedKey,
+                lastEvaluatedKey
             });
         } else {
             throw new Error("address == aggs == null");

--- a/src/routers/pagination.ts
+++ b/src/routers/pagination.ts
@@ -143,3 +143,80 @@ export const blockPagination = {
         }
     }
 };
+
+export const aggsUTXOPagination = {
+    byAssetType: {
+        forwardOrder: [["assetType", "DESC"]],
+        reverseOrder: [["assetType", "ASC"]],
+        orderby: (params: {
+            firstEvaluatedKey?: number[] | null;
+            lastEvaluatedKey?: number[] | null;
+        }) => {
+            const order = queryOrder(params);
+            if (order === "forward") {
+                return aggsUTXOPagination.byAssetType.forwardOrder;
+            } else if (order === "reverse") {
+                return aggsUTXOPagination.byAssetType.reverseOrder;
+            }
+        },
+        where: (params: {
+            firstEvaluatedKey?: number[] | null;
+            lastEvaluatedKey?: number[] | null;
+        }) => {
+            const order = queryOrder(params);
+            const { firstEvaluatedKey, lastEvaluatedKey } = params;
+            if (order === "forward") {
+                const assetType = lastEvaluatedKey![0];
+                return {
+                    assetType: {
+                        [Sequelize.Op.lt]: assetType
+                    }
+                };
+            } else if (order === "reverse") {
+                const assetType = firstEvaluatedKey![0];
+                return {
+                    assetType: {
+                        [Sequelize.Op.gt]: assetType
+                    }
+                };
+            }
+        }
+    },
+    byAddress: {
+        forwardOrder: [["address", "DESC"]],
+        reverseOrder: [["address", "ASC"]],
+        orderby: (params: {
+            firstEvaluatedKey?: number[] | null;
+            lastEvaluatedKey?: number[] | null;
+        }) => {
+            const order = queryOrder(params);
+            if (order === "forward") {
+                return aggsUTXOPagination.byAddress.forwardOrder;
+            } else if (order === "reverse") {
+                return aggsUTXOPagination.byAddress.reverseOrder;
+            }
+        },
+        where: (params: {
+            firstEvaluatedKey?: number[] | null;
+            lastEvaluatedKey?: number[] | null;
+        }) => {
+            const order = queryOrder(params);
+            const { firstEvaluatedKey, lastEvaluatedKey } = params;
+            if (order === "forward") {
+                const address = lastEvaluatedKey![0];
+                return {
+                    address: {
+                        [Sequelize.Op.lt]: address
+                    }
+                };
+            } else if (order === "reverse") {
+                const address = firstEvaluatedKey![0];
+                return {
+                    address: {
+                        [Sequelize.Op.gt]: address
+                    }
+                };
+            }
+        }
+    }
+};

--- a/src/routers/validator.ts
+++ b/src/routers/validator.ts
@@ -88,6 +88,11 @@ export const blockPaginationSchema = {
     firstEvaluatedKey: blockEvaluationKey
 };
 
+export const aggsUTXOPaginationSchema = {
+    firstEvaluatedKey: Joi.array().items(Joi.string()),
+    lastEvaluatedKey: Joi.array().items(Joi.string())
+};
+
 export const txSchema = {
     address,
     assetType: assetTypeSchema,

--- a/test/api/asset.spec.ts
+++ b/test/api/asset.spec.ts
@@ -132,7 +132,7 @@ describe("asset-api", function() {
             )
             .expect(200)
             .expect(res => {
-                const aggsUTXOs = JSON.parse(res.text);
+                const aggsUTXOs = JSON.parse(res.text).data;
                 expect(aggsUTXOs.length).equal(2);
                 const bobAggs = _.find(
                     aggsUTXOs,
@@ -157,7 +157,7 @@ describe("asset-api", function() {
             )
             .expect(200)
             .expect(res => {
-                const aggsUTXOs = JSON.parse(res.text);
+                const aggsUTXOs = JSON.parse(res.text).data;
                 const aggs = _.filter(
                     aggsUTXOs,
                     agg => agg.address === bobAddress
@@ -178,7 +178,7 @@ describe("asset-api", function() {
             )
             .expect(200)
             .expect(res => {
-                const aggsUTXOs = JSON.parse(res.text);
+                const aggsUTXOs = JSON.parse(res.text).data;
                 expect(aggsUTXOs.length).equal(1);
                 expect(aggsUTXOs[0].assetType).equal(assetType.toString());
                 expect(aggsUTXOs[0].address).equal(address);


### PR DESCRIPTION
The indexer was using SQL's `skip` for the pagination. The DB should scan the number of skipped rows, to get the page result. For the performance enhancement, we concluded that change the pagination method. Finding a particular row using an index and get the following `n` rows is much faster than using `skip`.

This commit uses `firstEvaluatedKey` and `lastEvaluatedKey` for the pagination in the AggsUTXO query. The AggsUTXO query will find a row using `firstEvaluatedKey` or `lastEvaluatedKey` and returns next `n` rows.