### PR TITLE
Use an index to find rows in the next page in the Tx query

### DIFF
--- a/src/models/logic/transaction.ts
+++ b/src/models/logic/transaction.ts
@@ -398,6 +398,7 @@ async function getHashesByPlatformAddress(params: {
     itemsPerPage: number;
     firstEvaluatedKey: [number, number] | null;
     lastEvaluatedKey: [number, number] | null;
+    includePending: boolean | null;
 }): Promise<string[]> {
     const {
         address,
@@ -409,7 +410,8 @@ async function getHashesByPlatformAddress(params: {
 
     const whereCond: any[] = [
         {
-            address
+            address,
+            ...(params.includePending !== true ? { isPending: false } : {})
         }
     ];
     if (firstEvaluatedKey || lastEvaluatedKey) {
@@ -449,6 +451,7 @@ async function getHashesByAssetAddress(params: {
     itemsPerPage: number;
     firstEvaluatedKey: [number, number] | null;
     lastEvaluatedKey: [number, number] | null;
+    includePending: boolean | null;
 }): Promise<string[]> {
     const {
         address,
@@ -462,7 +465,8 @@ async function getHashesByAssetAddress(params: {
     const whereCond: any[] = [
         {
             address,
-            ...(assetType && { assetType })
+            ...(assetType && { assetType }),
+            ...(params.includePending !== true ? { isPending: false } : {})
         }
     ];
     if (firstEvaluatedKey || lastEvaluatedKey) {
@@ -502,6 +506,7 @@ async function getHashesByAssetType(params: {
     itemsPerPage: number;
     firstEvaluatedKey: [number, number] | null;
     lastEvaluatedKey: [number, number] | null;
+    includePending: boolean | null;
 }): Promise<string[]> {
     const {
         assetType,
@@ -513,7 +518,8 @@ async function getHashesByAssetType(params: {
 
     const whereCond: any[] = [
         {
-            assetType
+            assetType,
+            ...(params.includePending !== true ? { isPending: false } : {})
         }
     ];
     if (firstEvaluatedKey || lastEvaluatedKey) {
@@ -563,7 +569,8 @@ async function getHashes(params: {
         page,
         itemsPerPage,
         firstEvaluatedKey,
-        lastEvaluatedKey
+        lastEvaluatedKey,
+        includePending = null
     } = params;
     if (address != null && assetType != null) {
         return getHashesByAssetAddress({
@@ -572,7 +579,8 @@ async function getHashes(params: {
             page,
             itemsPerPage,
             firstEvaluatedKey,
-            lastEvaluatedKey
+            lastEvaluatedKey,
+            includePending
         });
     } else if (address != null) {
         if (AssetAddress.check(address)) {
@@ -581,7 +589,8 @@ async function getHashes(params: {
                 page,
                 itemsPerPage,
                 firstEvaluatedKey,
-                lastEvaluatedKey
+                lastEvaluatedKey,
+                includePending
             });
         } else if (PlatformAddress.check(address)) {
             return getHashesByPlatformAddress({
@@ -589,7 +598,8 @@ async function getHashes(params: {
                 page,
                 itemsPerPage,
                 firstEvaluatedKey,
-                lastEvaluatedKey
+                lastEvaluatedKey,
+                includePending
             });
         }
         throw Error(`Invalid address: ${address}`);
@@ -599,7 +609,8 @@ async function getHashes(params: {
             page,
             itemsPerPage,
             firstEvaluatedKey,
-            lastEvaluatedKey
+            lastEvaluatedKey,
+            includePending
         });
     }
     const whereCond: any[] = [

--- a/src/routers/pagination.ts
+++ b/src/routers/pagination.ts
@@ -220,3 +220,39 @@ export const aggsUTXOPagination = {
         }
     }
 };
+
+export const txPagination = {
+    forwardOrder: [["blockNumber", "DESC"], ["transactionIndex", "DESC"]],
+    reverseOrder: [["blockNumber", "ASC"], ["transactionIndex", "ASC"]],
+    orderby: (params: {
+        firstEvaluatedKey?: number[] | null;
+        lastEvaluatedKey?: number[] | null;
+    }) => {
+        const order = queryOrder(params);
+        if (order === "forward") {
+            return txPagination.forwardOrder;
+        } else if (order === "reverse") {
+            return txPagination.reverseOrder;
+        }
+    },
+    where: (params: {
+        firstEvaluatedKey?: number[] | null;
+        lastEvaluatedKey?: number[] | null;
+    }) => {
+        const order = queryOrder(params);
+        const { firstEvaluatedKey, lastEvaluatedKey } = params;
+        if (order === "forward") {
+            const blockNumber = lastEvaluatedKey![0];
+            const transactionIndex = lastEvaluatedKey![1];
+            return Sequelize.literal(
+                `("blockNumber", "transactionIndex")<(${blockNumber}, ${transactionIndex})`
+            );
+        } else if (order === "reverse") {
+            const blockNumber = firstEvaluatedKey![0];
+            const transactionIndex = firstEvaluatedKey![1];
+            return Sequelize.literal(
+                `("blockNumber", "transactionIndex")>(${blockNumber}, ${transactionIndex})`
+            );
+        }
+    }
+};

--- a/src/routers/validator.ts
+++ b/src/routers/validator.ts
@@ -93,6 +93,11 @@ export const aggsUTXOPaginationSchema = {
     lastEvaluatedKey: Joi.array().items(Joi.string())
 };
 
+export const txPaginationSchema = {
+    firstEvaluatedKey: Joi.array().items(Joi.number(), Joi.number()),
+    lastEvaluatedKey: Joi.array().items(Joi.number(), Joi.number())
+};
+
 export const txSchema = {
     address,
     assetType: assetTypeSchema,


### PR DESCRIPTION
The indexer was using SQL's `skip` for the pagination. The DB should
scan the number of skipped rows, to get the page result. For the
performance enhancement, we concluded that change the pagination
method. Finding a particular row using an index and get the following
`n` rows is much faster than using `skip`.

This commit uses `firstEvaluatedKey` and `lastEvaluatedKey` for the
pagination in the Tx query. The Tx query will find a row using
`firstEvaluatedKey` or `lastEvaluatedKey` and returns next `n` rows.