### PR TITLE
Use an index to find rows in the next page in the PendingTx query

### DIFF
--- a/src/migrations/20191121041217-add-tx-index-for-pending.js
+++ b/src/migrations/20191121041217-add-tx-index-for-pending.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const tableName = "Transactions";
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.addIndex(
+            tableName,
+            ["isPending", "pendingTimestamp"],
+            {
+                where: {
+                    isPending: true
+                }
+            }
+        );
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        await queryInterface.removeIndex(
+            tableName,
+            ["isPending", "pendingTimestamp"],
+            {
+                where: {
+                    isPending: true
+                }
+            }
+        );
+    }
+};

--- a/src/migrations/20191121041429-add-seq-to-address-log.js
+++ b/src/migrations/20191121041429-add-seq-to-address-log.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const tableName = "AddressLogs";
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.addColumn(tableName, "seq", {
+            type: Sequelize.INTEGER
+        });
+        await queryInterface.addIndex(
+            tableName,
+            ["isPending", "address", "type", "seq"],
+            {
+                where: {
+                    type: "TransactionSigner"
+                }
+            }
+        );
+
+        await queryInterface.sequelize.query(
+            `UPDATE "AddressLogs"
+                SET "seq" = (SELECT "Transactions"."seq" FROM "Transactions" WHERE hash="AddressLogs"."transactionHash")
+                WHERE type='TransactionSigner'`
+        );
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        await queryInterface.removeIndex(
+            tableName,
+            ["isPending", "address", "type", "seq"],
+            {
+                where: {
+                    type: "TransactionSigner"
+                }
+            }
+        );
+        await queryInterface.removeColumn(tableName, "seq");
+    }
+};

--- a/src/routers/pagination.ts
+++ b/src/routers/pagination.ts
@@ -256,3 +256,81 @@ export const txPagination = {
         }
     }
 };
+
+export const addressLogPagination = {
+    bySeq: {
+        forwardOrder: [["seq", "ASC"]],
+        reverseOrder: [["seq", "DESC"]],
+        orderby: (params: {
+            firstEvaluatedKey?: number[] | null;
+            lastEvaluatedKey?: number[] | null;
+        }) => {
+            const order = queryOrder(params);
+            if (order === "forward") {
+                return addressLogPagination.bySeq.forwardOrder;
+            } else if (order === "reverse") {
+                return addressLogPagination.bySeq.reverseOrder;
+            }
+        },
+        where: (params: {
+            firstEvaluatedKey?: number[] | null;
+            lastEvaluatedKey?: number[] | null;
+        }) => {
+            const order = queryOrder(params);
+            const { firstEvaluatedKey, lastEvaluatedKey } = params;
+            if (order === "forward") {
+                const [seq] = lastEvaluatedKey!;
+                return {
+                    seq: {
+                        [Sequelize.Op.gt]: seq
+                    }
+                };
+            } else if (order === "reverse") {
+                const [seq] = firstEvaluatedKey!;
+                return {
+                    seq: {
+                        [Sequelize.Op.lt]: seq
+                    }
+                };
+            }
+        }
+    }
+};
+
+export const pendingTxPagination = {
+    forwardOrder: [["pendingTimestamp", "DESC"]],
+    reverseOrder: [["pendingTimestamp", "ASC"]],
+    orderby: (params: {
+        firstEvaluatedKey?: number[] | null;
+        lastEvaluatedKey?: number[] | null;
+    }) => {
+        const order = queryOrder(params);
+        if (order === "forward") {
+            return pendingTxPagination.forwardOrder;
+        } else if (order === "reverse") {
+            return pendingTxPagination.reverseOrder;
+        }
+    },
+    where: (params: {
+        firstEvaluatedKey?: number[] | null;
+        lastEvaluatedKey?: number[] | null;
+    }) => {
+        const order = queryOrder(params);
+        const { firstEvaluatedKey, lastEvaluatedKey } = params;
+        if (order === "forward") {
+            const [pendingTimestamp] = lastEvaluatedKey!;
+            return {
+                pendingTimestamp: {
+                    [Sequelize.Op.lt]: pendingTimestamp
+                }
+            };
+        } else if (order === "reverse") {
+            const [pendingTimestamp] = firstEvaluatedKey!;
+            return {
+                pendingTimestamp: {
+                    [Sequelize.Op.gt]: pendingTimestamp
+                }
+            };
+        }
+    }
+};

--- a/src/routers/validator.ts
+++ b/src/routers/validator.ts
@@ -98,6 +98,11 @@ export const txPaginationSchema = {
     lastEvaluatedKey: Joi.array().items(Joi.number(), Joi.number())
 };
 
+export const pendingTxPaginationSchema = {
+    firstEvaluatedKey: Joi.array().items(Joi.number()),
+    lastEvaluatedKey: Joi.array().items(Joi.number())
+};
+
 export const txSchema = {
     address,
     assetType: assetTypeSchema,
@@ -110,7 +115,6 @@ export const txSchema = {
 
 export const pendingTxSchema = {
     address,
-    assetType: assetTypeSchema,
     type,
     sync
 };

--- a/test/api/transaction.spec.ts
+++ b/test/api/transaction.spec.ts
@@ -248,18 +248,33 @@ describe("transaction-api", function() {
     });
 
     it("api /pending-tx", async function() {
-        await request(app)
-            .get(`/api/pending-tx`)
-            .expect(200);
-    });
-
-    it.skip("api /pending-tx with args", async function() {
-        const address = aliceAddress.value;
         const assetType = mintEmeraldTx.getMintedAsset().assetType;
         await request(app)
-            .get(
-                `/api/pending-tx?address=${address}&assetType=${assetType}&type=mintAsset`
-            )
-            .expect(200);
+            .get(`/api/pending-tx`)
+            .expect(200)
+            .expect(res => {
+                const txs = JSON.parse(res.text).data;
+                expect(txs.length).equals(1);
+
+                const mintAsset = txs[0].mintAsset;
+                expect(mintAsset.recipient).equals(aliceAddress.toString());
+                expect(mintAsset.assetType).equals(assetType.toString());
+            });
+    });
+
+    it("api /pending-tx with args", async function() {
+        const address = Helper.ACCOUNT_ADDRESS;
+        const assetType = mintEmeraldTx.getMintedAsset().assetType;
+        await request(app)
+            .get(`/api/pending-tx?address=${address}`)
+            .expect(200)
+            .expect(res => {
+                const txs = JSON.parse(res.text).data;
+                expect(txs.length).equals(1);
+
+                const mintAsset = txs[0].mintAsset;
+                expect(mintAsset.recipient).equals(aliceAddress.toString());
+                expect(mintAsset.assetType).equals(assetType.toString());
+            });
     });
 });


### PR DESCRIPTION
The indexer was using SQL's `skip` for the pagination. The DB should
scan the number of skipped rows, to get the page result. For the
performance enhancement, we concluded that change the pagination
method. Finding a particular row using an index and get the following
`n` rows is much faster than using `skip`.

This commit uses `firstEvaluatedKey` and `lastEvaluatedKey` for the
pagination in the PendingTx query. The PendingTx query will find a row
using `firstEvaluatedKey` or `lastEvaluatedKey` and returns next `n`
rows.