### PR TITLE
Use an index to find rows in the next page in the BalanceHistory query

### DIFF
--- a/src/migrations/20191121090356-add-pagination-index-to-ccc-changes.js
+++ b/src/migrations/20191121090356-add-pagination-index-to-ccc-changes.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const tableName = "CCCChanges";
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.addIndex(tableName, [
+            "address",
+            "reason",
+            "blockNumber",
+            "id"
+        ]);
+    },
+
+    down: async (queryInterface, Sequelize) => {
+        await queryInterface.removeIndex(tableName, [
+            "address",
+            "reason",
+            "blockNumber",
+            "id"
+        ]);
+    }
+};

--- a/src/models/cccChanges.ts
+++ b/src/models/cccChanges.ts
@@ -22,6 +22,7 @@ export const defaultAllReasons = [
 ];
 
 export interface CCCChangeAttribute {
+    id?: string;
     address: string;
     change: string;
     blockNumber: number;

--- a/src/routers/pagination.ts
+++ b/src/routers/pagination.ts
@@ -297,6 +297,42 @@ export const addressLogPagination = {
     }
 };
 
+export const cccChangesPagination = {
+    byAccount: {
+        forwardOrder: [["blockNumber", "DESC"], ["id", "DESC"]],
+        reverseOrder: [["blockNumber", "ASC"], ["id", "ASC"]],
+        orderby: (params: {
+            firstEvaluatedKey?: number[] | null;
+            lastEvaluatedKey?: number[] | null;
+        }) => {
+            const order = queryOrder(params);
+            if (order === "forward") {
+                return cccChangesPagination.byAccount.forwardOrder;
+            } else if (order === "reverse") {
+                return cccChangesPagination.byAccount.reverseOrder;
+            }
+        },
+        where: (params: {
+            firstEvaluatedKey?: number[] | null;
+            lastEvaluatedKey?: number[] | null;
+        }) => {
+            const order = queryOrder(params);
+            const { firstEvaluatedKey, lastEvaluatedKey } = params;
+            if (order === "forward") {
+                const [blockNumber, id] = lastEvaluatedKey!;
+                return Sequelize.literal(
+                    `("CCCChange"."blockNumber", "id")<(${blockNumber}, ${id})`
+                );
+            } else if (order === "reverse") {
+                const [blockNumber, id] = firstEvaluatedKey!;
+                return Sequelize.literal(
+                    `("CCCChange"."blockNumber", "id")>(${blockNumber}, ${id})`
+                );
+            }
+        }
+    }
+};
+
 export const pendingTxPagination = {
     forwardOrder: [["pendingTimestamp", "DESC"]],
     reverseOrder: [["pendingTimestamp", "ASC"]],

--- a/src/routers/validator.ts
+++ b/src/routers/validator.ts
@@ -103,6 +103,11 @@ export const pendingTxPaginationSchema = {
     lastEvaluatedKey: Joi.array().items(Joi.number())
 };
 
+export const accountBalanceHistoryPaginationSchema = {
+    firstEvaluatedKey: Joi.array().items(Joi.number(), Joi.string()),
+    lastEvaluatedKey: Joi.array().items(Joi.number(), Joi.string())
+};
+
 export const txSchema = {
     address,
     assetType: assetTypeSchema,


### PR DESCRIPTION
The indexer was using SQL's `skip` for the pagination. The DB should scan the number of skipped rows, to get the page result. For the performance enhancement, we concluded that change the pagination method. Finding a particular row using an index and get the following `n` rows is much faster than using `skip`.

This commit uses `firstEvaluatedKey` and `lastEvaluatedKey` for the pagination in the BalanceHistory query. The BalanceHistory query will find a row using `firstEvaluatedKey` or `lastEvaluatedKey` and returns next `n` rows.