### PR TITLE
Use an index to find rows in the next page in the BlockTxs query

### DIFF
--- a/src/routers/pagination.ts
+++ b/src/routers/pagination.ts
@@ -144,6 +144,44 @@ export const blockPagination = {
     }
 };
 
+export const blockTxPagination = {
+    forwardOrder: [["transactionIndex", "DESC"]],
+    reverseOrder: [["transactionIndex", "ASC"]],
+    orderby: (params: {
+        firstEvaluatedKey?: number[] | null;
+        lastEvaluatedKey?: number[] | null;
+    }) => {
+        const order = queryOrder(params);
+        if (order === "forward") {
+            return blockTxPagination.forwardOrder;
+        } else if (order === "reverse") {
+            return blockTxPagination.reverseOrder;
+        }
+    },
+    where: (params: {
+        firstEvaluatedKey?: number[] | null;
+        lastEvaluatedKey?: number[] | null;
+    }) => {
+        const order = queryOrder(params);
+        const { firstEvaluatedKey, lastEvaluatedKey } = params;
+        if (order === "forward") {
+            const transactionIndex = lastEvaluatedKey![0];
+            return {
+                transactionIndex: {
+                    [Sequelize.Op.lt]: transactionIndex
+                }
+            };
+        } else if (order === "reverse") {
+            const transactionIndex = firstEvaluatedKey![0];
+            return {
+                transactionIndex: {
+                    [Sequelize.Op.gt]: transactionIndex
+                }
+            };
+        }
+    }
+};
+
 export const aggsUTXOPagination = {
     byAssetType: {
         forwardOrder: [["assetType", "DESC"]],

--- a/src/routers/validator.ts
+++ b/src/routers/validator.ts
@@ -88,6 +88,11 @@ export const blockPaginationSchema = {
     firstEvaluatedKey: blockEvaluationKey
 };
 
+export const blockTxPaginationSchema = {
+    firstEvaluatedKey: Joi.array().items(Joi.number()),
+    lastEvaluatedKey: Joi.array().items(Joi.number())
+};
+
 export const aggsUTXOPaginationSchema = {
     firstEvaluatedKey: Joi.array().items(Joi.string()),
     lastEvaluatedKey: Joi.array().items(Joi.string())


### PR DESCRIPTION
The indexer was using SQL's `skip` for the pagination. The DB should
scan the number of skipped rows, to get the page result. For the
performance enhancement, we concluded that change the pagination
method. Finding a particular row using an index and get the following
`n` rows is much faster than using `skip`.

This commit uses `firstEvaluatedKey` and `lastEvaluatedKey` for the
pagination in the BlockTxs query. The BlockTxs query will
find a row using `firstEvaluatedKey` or `lastEvaluatedKey` and returns
next `n` rows.