### PR TITLE
Fix snapshot pagination bug

### DIFF
--- a/src/models/logic/utxo.ts
+++ b/src/models/logic/utxo.ts
@@ -506,8 +506,7 @@ export async function getSnapshot(params: {
                     transaction,
                     type: sequelize.QueryTypes.SELECT
                 }
-            )).count ===
-            itemsPerPage + 1;
+            )).count === String(itemsPerPage + 1);
 
         // The SQL query is copied from the query above.
         const lastRow = await models.sequelize.query(

--- a/src/routers/asset.ts
+++ b/src/routers/asset.ts
@@ -540,7 +540,10 @@ export function handle(context: IndexerContext, router: Router) {
         async (req, res, next) => {
             const assetTypeString = req.query.assetType;
             const date = req.query.date;
-            const lastEvaluatedKey = req.query.lastEvaluatedKey;
+            let lastEvaluatedKey = req.query.lastEvaluatedKey;
+            if (typeof lastEvaluatedKey === "string") {
+                lastEvaluatedKey = JSON.parse(lastEvaluatedKey);
+            }
             try {
                 const assetType = new H160(assetTypeString);
                 const snapshotTime = moment(date);


### PR DESCRIPTION
* I checked the result of the query by creating a small JavaScript program. Its result was `{ count: '2' }`.
* I found that there were no point that deserializing the query parameter. I checked it by printing the lastEvaluatedKey after `JSON.parse`. It can handle a query like `curl -vG 'localhost:9001/api/snapshot?assetType=30a62cfe15b1993b26f95d86234da236ec4e02c2&date=2020-04-20' --data-urlencode 'lastEvaluatedKey=[0,0]'